### PR TITLE
Making the module compatible with the last version of magisk

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=hide-navbar-prop
 name=Hide navigation bar
-version=v02
+version=v03
 versionCode=2
 author=AndroPlus
 description=Simple module to hide navigation bar.
-minMagisk=1500
+minMagisk=1700


### PR DESCRIPTION
In the current state, the module is not appearing in the list of magisk online repos and installing the module manually makes the device stuck into bootloop.

Having the minMagisk version update according to the magisk templates guidelines here: https://topjohnwu.github.io/Magisk/guides.html#magisk-module-template seems to solve the issue.